### PR TITLE
Error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 test/setup/config.js
 node_modules
 *.log
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Return Object Element | Meaning
 `statusCode` | This element represents the HTTP statusCode of the API response.
 `xhtml` | This is the raw response from the server
 `data` | This element represents parsed XHTML into JSON when possible for GET requests.
+`error` | Boolean value represents the presence or absence of a business logic error. For example, adding an invalid netid to a valid group returns a `statusCode` of 200 but `error` = false
+`message` | Array of error messages if `error` is true. There will generally be only one value unless you attempted to add multiple invalid netids to a group. Then each invalid id will generate an item in the `message` array.
 
 All of the `options` parameters are outlined in `src/modules/[endpoint]`.
 
@@ -72,6 +74,15 @@ Endpoint  | Implementation
 [Search - Query](https://wiki.cac.washington.edu/display/infra/Groups+WebService+Search) | `uwgws.search.query(options)`
 
 ## Development
-Copy `test/setup/config-sample.js` to `test/setup/config.js` and edit values as needed. Use the `npm` commands indicated in `package.json`. It is recommended that you use the `eval` environment when developing/testing to avoid making lasting changes.
 
+    git clone git@github.com:UWFosterIT/node-gws.git
+    cd node-gws
+    # create a branch as needed. don't work on master
+    yarn install
+    cp test/setup/config-sample.js test/setup/config.js
+    # put appropriate values in the new config.js
     npm test
+
+It is recommended that you use the eval environment (https://eval.groups.uw.edu/group_sws/v2/) when developing/testing to avoid making lasting changes. And the search test will occassionaly timeout if you are using prod.
+
+Run `npm run lint` and fix any errors or warnings before checking in your code.

--- a/lib/modules/membership.js
+++ b/lib/modules/membership.js
@@ -45,12 +45,15 @@ class Membership extends Service {
 
   del(opt) {
     if (!opt.netid) {
+      let msg = 'Member delete must include a list of id(s)';
       return {
+        error:      true,
+        message:    [msg],
         statusCode: 400,
         xhtml:      `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
                     <html xmlns="http://www.w3.org/1999/xhtml">
                     <head><title>Bad Request</title></head>
-                    <body>Member delete must include a list of id(s).</body></html>`
+                    <body>${msg}</body></html>`
       };
     }
     return this._del(`group/${opt.id}/member/${opt.netid}`)

--- a/lib/modules/service.js
+++ b/lib/modules/service.js
@@ -1,4 +1,5 @@
 let _       = require('underscore');
+let cheerio = require('cheerio');
 let fs      = require('fs');
 let path    = require('path');
 let request = require('request');
@@ -109,7 +110,39 @@ class Service {
   }
 
   _buildResult(response, body) {
+    let err = false;
+    let msg = [];
+    const $ = cheerio.load(body);
+
+    // Not found, unauthorized
+    if (response.statusCode == 404 || response.statusCode == 401) {
+      err = true;
+      // Add and Get return errors in different formats because why not?
+      let message = $('.alert').text();
+      if (message == '') {
+        message = $('.error_message').text()
+      }
+
+      // History (and probably others) don't include error messages because of course.
+      if (message == '') {
+        message = 'Unknown error. Most likely the group does not exist.';
+      }
+
+      msg.push(message.trim());
+    }
+
+    // Problems with adds
+    let missing = $('.notfoundmembers').find($('.notfoundmember')).length;
+    if (missing > 0) {
+      err = true;
+      $('.notfoundmember').each(function(i, elem) {
+        msg.push($(this).text() + ' is not a valid netid');
+      });
+    }
+
     return {
+      error:      err,
+      message:    msg,
       statusCode: response.statusCode,
       xhtml:      body
     };

--- a/lib/modules/service.js
+++ b/lib/modules/service.js
@@ -131,7 +131,7 @@ class Service {
       msg.push(message.trim());
     }
 
-    // Problems with adds
+    // Invalid netids sent into the Add method are returned in a list in the html
     let missing = $('.notfoundmembers').find($('.notfoundmember')).length;
     if (missing > 0) {
       err = true;
@@ -140,6 +140,13 @@ class Service {
       });
     }
 
+    // Catch any error not spefically handled above. These can be handled more
+    // specifically and given a better error message if needed.
+    // I'm doing this to make the error field consistently return true
+    if (!err && (response.statusCode < 200 || response.statusCode >= 300)) {
+      err = true;
+      msg.push('An error occured while processing your request.');
+    }
     return {
       error:      err,
       message:    msg,

--- a/lib/modules/service.js
+++ b/lib/modules/service.js
@@ -120,7 +120,7 @@ class Service {
       // Add and Get return errors in different formats because why not?
       let message = $('.alert').text();
       if (message == '') {
-        message = $('.error_message').text()
+        message = $('.error_message').text();
       }
 
       // History (and probably others) don't include error messages because of course.
@@ -135,8 +135,8 @@ class Service {
     let missing = $('.notfoundmembers').find($('.notfoundmember')).length;
     if (missing > 0) {
       err = true;
-      $('.notfoundmember').each(function(i, elem) {
-        msg.push($(this).text() + ' is not a valid netid');
+      $('.notfoundmember').each(function () {
+        msg.push(`${$(this).text()} is not a valid netid`);
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwgws",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Client Library for University of Washington's Groups Web Service",
   "bugs:": {
     "url": "https://github.com/UWFosterIT/node-gws/issues"

--- a/test/unit/group-test.js
+++ b/test/unit/group-test.js
@@ -53,6 +53,7 @@ describe('Group', () => {
     expect(result.message.length).to.eql(0);
   });
 
+  // Error handling
   it('should return an error when getting an invalid group', async () => {
     let query  = {id: nonGroup};
     let result = await uwgws.group.get(query);

--- a/test/unit/group-test.js
+++ b/test/unit/group-test.js
@@ -10,6 +10,9 @@ let options = {
   title:       'Foster GWS Test'
 };
 
+let nonGroup = 'fake_group_that_is_not_real_at_all';
+let unauthorizedGroup = 'uw_employee';
+
 describe('Group', () => {
   beforeEach(() => {
     uwgws.initialize(config);
@@ -23,12 +26,15 @@ describe('Group', () => {
   it('should create a group', async () => {
     let result = await uwgws.group.create(options);
     expect(result.statusCode).to.equal(201);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
   });
 
   it('should get a group', async () => {
     let query  = {id: options.name};
     let result = await uwgws.group.get(query);
-    expect(result.statusCode).to.eql(200);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
     expect(result.data.contact).to.eql('milesm');
     expect(result.data.description).to.eql('Created as part of an automated test https://github.com/UWFosterIT/node-uwgws');
     expect(result.data.title).to.eql('Foster GWS Test');
@@ -38,9 +44,35 @@ describe('Group', () => {
     options.name = `${options.name}_delete`;
     let result = await uwgws.group.create(options);
     expect(result.statusCode).to.eql(201);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
 
     result = await uwgws.group.del({id: options.name});
     expect(result.statusCode).to.eql(200);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
+  });
+
+  it('should return an error when getting an invalid group', async () => {
+    let query  = {id: nonGroup};
+    let result = await uwgws.group.get(query);
+    expect(result.statusCode).to.eql(404);
+    expect(result.error).to.eql(true);
+    expect(result.message.length).to.eql(1);
+  });
+
+  it('does not return an error when trying to delete an invalid group', async () => {
+    result = await uwgws.group.del({id: nonGroup});
+    expect(result.statusCode).to.eql(200);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
+  });
+
+  it('should return an error when trying to delete you are not authorized to administer', async () => {
+    result = await uwgws.group.del({id: unauthorizedGroup});
+    expect(result.statusCode).to.eql(401);
+    expect(result.error).to.eql(true);
+    expect(result.message.length).to.eql(1);
   });
 
 });

--- a/test/unit/membership-test.js
+++ b/test/unit/membership-test.js
@@ -2,6 +2,8 @@
 require('../setup');
 
 let group = 'uw_foster_staff_it_developers_nodegws-test_group';
+let nonGroup = 'fake_group_that_is_not_real_at_all';
+let unauthorizedGroup = 'uw_employee';
 
 describe('Membership', () => {
 
@@ -24,6 +26,8 @@ describe('Membership', () => {
 
       let result = await uwgws.membership.add(options);
       expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
     });
 
     it('should add multiple members to a group', async () => {
@@ -34,6 +38,8 @@ describe('Membership', () => {
 
       let result = await uwgws.membership.add(options);
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
     });
 
     it('should add a rollup group', async () => {
@@ -44,7 +50,83 @@ describe('Membership', () => {
 
       let result = await uwgws.membership.add(options);
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
     });
+
+    // Catching add errors
+    it('should return an error if the netid is invalid', async () => {
+      let options = {
+        id:    group,
+        netid: 'dgalefakenetid'
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
+    it('should return an error if the group is invalid', async () => {
+      let options = {
+        id:    nonGroup,
+        netid: 'dgale'
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.equal(404);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
+    it('should return an error if any net ids are invalid', async () => {
+      let options = {
+        id:    group,
+        netid: ['dgalefakenetid', 'gabugabufakenetid', 'schad']
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.eql(200);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(2);
+    });
+
+    it('does NOT throw an error when adding an existing member', async () => {
+      let options = {
+        id:    group,
+        netid: 'milesm'
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
+    });
+
+    it('should return an error when adding an invalid rollup group', async () => {
+      let options = {
+        id:    group,
+        netid: nonGroup
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.eql(200);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
+    it('should return an error when adding a member to a group not authorized to administer', async () => {
+      let options = {
+        id:    unauthorizedGroup,
+        netid: 'dgale'
+      };
+
+      let result = await uwgws.membership.add(options);
+      expect(result.statusCode).to.equal(401);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
   });
 
   describe('Delete', () => {
@@ -54,10 +136,58 @@ describe('Membership', () => {
         netid: 'schad'
       };
 
-      let result = await uwgws.membership.add(options);
-      expect(result.statusCode).to.equal(200);
       result = await uwgws.membership.del(options);
       expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
+    });
+
+    it('does NOT throw an error when deleting a non-member (valid netid) from the group', async () => {
+      let options = {
+        id:    group,
+        netid: 'schad'
+      };
+
+      result = await uwgws.membership.del(options);
+      expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
+    });
+
+    it('does NOT throw an error when attemping to delete an invalid netid from the group', async () => {
+      let options = {
+        id:    group,
+        netid: 'schadfakenetidn'
+      };
+
+      result = await uwgws.membership.del(options);
+      expect(result.statusCode).to.equal(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
+    });
+
+    it('throws an error when attemping to delete from an invalid group', async () => {
+      let options = {
+        id:    nonGroup,
+        netid: 'dgale'
+      };
+
+      result = await uwgws.membership.del(options);
+      expect(result.statusCode).to.equal(404);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
+    it('throws an error when attemping to delete from a group we are not authorized to administer', async () => {
+      let options = {
+        id:    unauthorizedGroup,
+        netid: 'dgale'
+      };
+
+      result = await uwgws.membership.del(options);
+      expect(result.statusCode).to.equal(401);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
     });
 
     it('should not delete all members from the group', async () => {
@@ -65,7 +195,10 @@ describe('Membership', () => {
 
       let result = await uwgws.membership.del(options);
       expect(result.statusCode).to.equal(400);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
     });
+
   });
 
   describe('Get', () => {
@@ -76,7 +209,10 @@ describe('Membership', () => {
 
       // this test occasionally returns 404
       let result = await uwgws.membership.get(options);
-      expect(result.data.length).to.be.within(1, 4);
+      expect(result.statusCode).to.eql(200);
+      expect(result.data.length).to.be.within(1, 5);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
     });
 
     it('should return effective membership', async () => {
@@ -87,6 +223,8 @@ describe('Membership', () => {
 
       let result = await uwgws.membership.get(options);
       expect(result.data.length).to.be.within(10, 20);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
     });
 
     it('should return the membership history for a group', async () => {
@@ -94,8 +232,31 @@ describe('Membership', () => {
       let result = await uwgws.group.history(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.equal(false);
+      expect(result.message.length).to.equal(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.eql(6);
+    });
+
+    // Error handling
+    it('from an invalid group returns an error', async () => {
+      let options = {id: nonGroup};
+
+      let result = await uwgws.membership.get(options);
+      expect(result.statusCode).to.eql(404);
+      expect(result.data.length).to.equal(0);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+    });
+
+
+    it('history for an invalid group returns an error', async () => {
+      let query  = {id: nonGroup};
+      let result = await uwgws.group.history(query);
+      expect(result.statusCode).to.eql(404);
+      expect(result.error).to.equal(true);
+      expect(result.message.length).to.equal(1);
+      expect(result.data.length).to.equal(0);
     });
 
   });

--- a/test/unit/search-test.js
+++ b/test/unit/search-test.js
@@ -12,6 +12,8 @@ describe('Search', () => {
     let result = await uwgws.search.query(query);
 
     expect(result.statusCode).to.eql(200);
+    expect(result.error).to.eql(false);
+    expect(result.message.length).to.eql(0);
     expect(Array.isArray(result.data)).to.eql(true);
     expect(result.data.length).to.be.greaterThan(10);
   });
@@ -24,6 +26,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(10);
       scopedCount = result.data.length;
@@ -37,6 +41,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(10);
       expect(result.data.length).to.be.greaterThan(scopedCount);
@@ -51,6 +57,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(10);
       directCount = result.data.length;
@@ -64,6 +72,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(10);
       expect(result.data.length).to.be.greaterThan(directCount);
@@ -78,6 +88,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(5);
       directCount = result.data.length;
@@ -91,6 +103,8 @@ describe('Search', () => {
       let result = await uwgws.search.query(query);
 
       expect(result.statusCode).to.eql(200);
+      expect(result.error).to.eql(false);
+      expect(result.message.length).to.eql(0);
       expect(Array.isArray(result.data)).to.eql(true);
       expect(result.data.length).to.be.greaterThan(10);
       expect(result.data.length).to.be.greaterThan(directCount);


### PR DESCRIPTION
@Nogbit,

Currently if you add invalid and valid netids to a group via GWS, it will:
 - add the valid ids
 - return `statusCode` of 200
 - return a list of the invalid netids in `xhtml`

If a consumer wanted to know what happened with a batch add of netids, they'd needed to parse the xhtml. 

This change adds two fields to the return object `error` and `message`. The `error` field is set to true if:
- invalid netids were sent in to be added to a group
- gws returns any status code not between 200-299

When such error occur, the xhtml is parsed to determine the problem and places in the `message` array. Generally speaking, there should only be one element in that array. If multiple invalid netids are rejected, each one is generates an entry in the `message` array.

The README has been updated to include this change (plus an expansion to the development section)

yarn.lock was added to `.gitignore` to keep it out of the repo